### PR TITLE
Update LegacyWalletResponse – make `risk_score` optional

### DIFF
--- a/elliptic_sdk/schemas.py
+++ b/elliptic_sdk/schemas.py
@@ -63,4 +63,4 @@ class LegacyWalletResponse(BaseModel):
     error: str | None
     team_id: uuid.UUID
     asset_tier: str
-    risk_score: float
+    risk_score: float | None


### PR DESCRIPTION
```python
aml = AML()
payload = LegacyWalletPayload(
    subject=subject,
    customer_reference=customer_reference,
)
response = aml.legacy_wallet(payload)  # <– HERE
return response.risk_score
```

```bash
1 validation error for LegacyWalletResponse
risk_score
  none is not an allowed value (type=type_error.none.not_allowed)
```